### PR TITLE
fix(tests) mock the nextjs server-only import

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -1,7 +1,13 @@
 import httpMocks from "node-mocks-http";
 
-import {test} from "vitest"
-import {POST} from "./api/test/route";
+import { test, vi } from "vitest";
+import { POST } from "./api/test/route";
+
+vi.mock("server-only", () => {
+  return {
+    // mock server-only module
+  };
+});
 
 test('can test api', async () => {
   const mockRequestData = { };


### PR DESCRIPTION
According to your issue #60038 on vercel/next.js this is a possible solution to fix the 'server-only' import problem in your vitest.  
